### PR TITLE
3rd person view

### DIFF
--- a/src/core/ArxGame.cpp
+++ b/src/core/ArxGame.cpp
@@ -1306,17 +1306,21 @@ void ArxGame::updateFirstPersonCamera() {
 			g_playerCamera.m_pos.x -= distance * angle.x + horizontalOffset * offset.x;
 			g_playerCamera.m_pos.y -= distance * angle.y;
 			g_playerCamera.m_pos.z -= distance * angle.z + horizontalOffset * offset.z;
+
+			EXTERNALVIEW = 1;
 			
 		} else {
 			g_playerCameraStablePos = g_playerCamera.m_pos = player.basePosition();
 		}
 		
 	}
-	
+
+	/*
 	if(EXTERNALVIEW) {
 		g_playerCameraStablePos = g_playerCamera.m_pos = (g_playerCamera.m_pos + targetPos) * 0.5f;
 		g_playerCamera.angle = interpolate(g_playerCamera.angle, targetAngle, 0.1f);
 	}
+	*/
 	
 }
 

--- a/src/core/ArxGame.cpp
+++ b/src/core/ArxGame.cpp
@@ -1294,6 +1294,18 @@ void ArxGame::updateFirstPersonCamera() {
 				g_playerCamera.m_pos.x = player.pos.x + vect.x;
 				g_playerCamera.m_pos.z = player.pos.z + vect.z;
 			}
+
+			// ----------
+
+			int distance = 150;
+			int horizontalOffset = -65;
+
+			Vec3f angle = angleToVector(player.angle);
+			Vec3f offset = VRotateY(angle, 90);
+
+			g_playerCamera.m_pos.x -= distance * angle.x + horizontalOffset * offset.x;
+			g_playerCamera.m_pos.y -= distance * angle.y;
+			g_playerCamera.m_pos.z -= distance * angle.z + horizontalOffset * offset.z;
 			
 		} else {
 			g_playerCameraStablePos = g_playerCamera.m_pos = player.basePosition();
@@ -1717,7 +1729,10 @@ void ArxGame::updateLevel() {
 		std::pair<Vec3f, Vec3f> frontUp = angleToFrontUpVec(g_camera->angle);
 		ARX_SOUND_SetListener(g_camera->m_pos, frontUp.first, frontUp.second);
 	}
-	
+
+	ARX_INTERACTIVE_Show_Hide_1st(entities.player(), 0);
+
+	/*
 	// Check For Hiding/unHiding Player Gore
 	if(EXTERNALVIEW || player.lifePool.current <= 0) {
 		ARX_INTERACTIVE_Show_Hide_1st(entities.player(), 0);
@@ -1726,6 +1741,7 @@ void ArxGame::updateLevel() {
 	if(!EXTERNALVIEW) {
 		ARX_INTERACTIVE_Show_Hide_1st(entities.player(), 1);
 	}
+	*/
 
 	PrepareIOTreatZone();
 	ARX_PHYSICS_Apply();


### PR DESCRIPTION
Tasks that need to be done:

- [x] Create a basic/hacky version of 3rd person view
- [ ] Add a variable to keep track of view modes (3rd person vs 1st person) and set that to 1st person by default
- [ ] Add hotkey in controls to allow toggling between the two modes
- [ ] Add possibility to control view mode via scripting
- [ ] Add slider in interface controls to control the horizontal offset parameter
- [ ] Add hotkey to control the distance (zoom in/zoom out) - maybe mousewheel?
- [ ] Add possibility to control the distance and horizontal offset parameters via scripting
- [ ] Utilize the recommendations from dscharrer at https://github.com/arx/ArxLibertatis/pull/269
- [ ] Do a simple raytracing in the camera's direction and move the camera closer, when terrain obstructs the view
- [ ] If camera is too close, then automatically switch to first person, until the camera has enough space again for 3rd person view
- [ ] optionally: create a view mode where the player is being viewed from the front, camera looking back (like in minecraft)
- [ ] optionally: create a view mode where the camera can be moved freely around the player

Issues discovered:

- [ ] horizontal position of items are misaligned after picking up and dragging
- [ ] weapon on player's back seems to be flipped (for example: axe)
- [ ] might need to increase the reach of the player
- [ ] torch light is coming from camera position, not from the player

![image](https://user-images.githubusercontent.com/2386064/170834288-68acf989-5faa-49d2-bdc2-1717d834944d.png)
