### PR TITLE
always show the equipment icons + add blue color to mark pristine condition

### DIFF
--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1207,8 +1207,10 @@ void DamagedEquipmentGui::update() {
 		Entity * io = entities.get(player.equiped[eq]);
 		if(io) {
 			float ratio = io->durability / io->max_durability;
-			if(ratio <= 0.5f) {
+			if(ratio < 1.0f) {
 				m_colors[i] = Color::rgb(1.f - ratio, ratio, 0);
+			} else {
+				m_colors[i] = Color::rgb(0, 0.615f, 1.f);
 			}
 		}
 		

--- a/src/gui/Hud.cpp
+++ b/src/gui/Hud.cpp
@@ -1210,7 +1210,7 @@ void DamagedEquipmentGui::update() {
 			if(ratio < 1.0f) {
 				m_colors[i] = Color::rgb(1.f - ratio, ratio, 0);
 			} else {
-				m_colors[i] = Color::rgb(0, 0.615f, 1.f);
+				m_colors[i] = Color::rgb(0, 1.f, 1.f);
 			}
 		}
 		


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2386064/186241135-254f2311-cdf0-40b5-a175-fd33f62092a6.png)

fixes #4 