### PR TITLE
Add support for the INVENTORYOUT event

### DIFF
--- a/src/game/Inventory.cpp
+++ b/src/game/Inventory.cpp
@@ -142,6 +142,21 @@ static void ARX_INVENTORY_Declare_InventoryIn(Entity * io, Entity * container) {
 	
 }
 
+/*!
+ * Declares an IO as exiting the player's inventory
+ * Sends appropriate INVENTORYOUT Event to player AND concerned io.
+ */
+static void ARX_INVENTORY_Declare_InventoryOut(Entity * io, Entity * container) {
+	
+	arx_assert(io);
+	
+	SendIOScriptEvent(io, container, SM_INVENTORYOUT);
+	if(container == entities.player()) {
+		// Items only receive the event when they are put in front of the player inventory because scripts expect that
+		SendIOScriptEvent(entities.player(), io, SM_INVENTORYOUT);
+	}
+}
+
 //! Puts an IO in front of the player
 void PutInFrontOfPlayer(Entity * io) {
 	
@@ -443,6 +458,8 @@ void Inventory::remove(Entity & item) {
 	
 	arx_assert(item.ioflags & IO_ITEM);
 	arx_assert(item.owner() == owner());
+
+	Entity * previousOwner = &m_owner;
 	
 	Vec3s pos = item._itemdata->m_inventoryPos;
 	arx_assert(pos.x >= 0 && pos.y >= 0 && pos.z >= 0);
@@ -466,6 +483,8 @@ void Inventory::remove(Entity & item) {
 	item._itemdata->m_inventoryPos = Vec3s(-1);
 	
 	item.updateOwner();
+
+	ARX_INVENTORY_Declare_InventoryOut(&item, previousOwner);
 	
 }
 


### PR DESCRIPTION
This change introduces support for the INVENTORYOUT event.

A new helper function, ARX_INVENTORY_Declare_InventoryOut, has been added to handle dispatching the SM_INVENTORYOUT event when an item leaves an inventory.

The event is triggered from Inventory::remove(), ensuring it is called to provide the correct context to scripts.

This change makes inventory event handling symmetrical and enables scripts to properly react when items are removed from inventories.